### PR TITLE
parse_html.activity._parse_html_activity: fix regression in bs4 >= 4.13.0 and add a unit test for html activity parsing

### DIFF
--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -1,0 +1,57 @@
+from datetime import datetime, timezone
+
+from google_takeout_parser.models import Activity, LocationInfo
+from google_takeout_parser.parse_html.activity import _parse_html_activity
+
+from .common import this_dir
+
+
+def test_parse_html_activity() -> None:
+
+    activity_html = this_dir / "testdata/HtmlTakeout/My Activity/Chrome/MyActivity.html"
+
+    results = list(_parse_html_activity(activity_html))
+
+    assert results == [
+        Activity(
+            header="Search",
+            title="Visited https://productforums.google.com/forum/",
+            time=datetime(2018, 1, 31, 22, 54, 50, tzinfo=timezone.utc),
+            description=None,
+            titleUrl="https://productforums.google.com/forum/",
+            subtitles=[],
+            details=[],
+            locationInfos=[],
+            products=["Search"],
+        ),
+        Activity(
+            header="Search",
+            title="Visited http://www.adobe.com/creativecloud.html",
+            time=datetime(2017, 2, 8, 0, 32, 39, tzinfo=timezone.utc),
+            description=None,
+            titleUrl="https://www.google.com/url?q=http://www.adobe.com/creativecloud.html&usg=AFQjCNH6fum5tBw7J0dbmUYKGFPduC0vSg",
+            subtitles=[],
+            details=[],
+            locationInfos=[],
+            products=["Search"],
+        ),
+        Activity(
+            header="Search",
+            title="Searched for adobe creative cloud",
+            time=datetime(2017, 2, 8, 0, 32, 36, tzinfo=timezone.utc),
+            description=None,
+            titleUrl="https://www.google.com/search?q=adobe+creative+cloud",
+            subtitles=[],
+            details=[],
+            locationInfos=[
+                LocationInfo(
+                    name="From your home: https://google.com/maps?q=25.800819,",
+                    url=None,
+                    source="80.186310",
+                    sourceUrl="https://google.com/maps?q=25.800819,-80.186310",
+                ),
+                LocationInfo(name=None, url=None, source="", sourceUrl=None),
+            ],
+            products=["Search"],
+        ),
+    ]

--- a/tests/testdata/HtmlTakeout/My Activity/Chrome/MyActivity.html
+++ b/tests/testdata/HtmlTakeout/My Activity/Chrome/MyActivity.html
@@ -1,0 +1,48 @@
+<html><head><title>My Activity History</title><style type="text/css">
+body {
+  padding: 5px;
+  background: #EEEEEE;
+}
+
+.mdl-cell {
+  background-color: #FFFFFF;
+}
+
+.content-cell.mdl-cell {
+  color: rgba(0, 0, 0, 0.54);
+}
+
+.header-cell.mdl-cell {
+  border-bottom-style: solid;
+  border-bottom-width: 1px;
+  border-bottom-color: rgba(0, 0, 0, 0.1);
+}
+
+.image-preview {
+  width:72px;
+  height:72px;
+}
+
+</style></head><body><div class="mdl-grid">
+
+
+
+
+
+<div class="outer-cell mdl-cell mdl-cell--12-col mdl-shadow--2dp"><div class="mdl-grid"><div class="header-cell mdl-cell mdl-cell--12-col"><p class="mdl-typography--title">Search<br></p></div>
+<div class="content-cell mdl-cell mdl-cell--6-col mdl-typography--body-1">Visited&nbsp;<a href="https://productforums.google.com/forum/">https://productforums.google.com/forum/</a><br>Jan 31, 2018, 10:54:50 PM</div>
+<div class="content-cell mdl-cell mdl-cell--6-col mdl-typography--body-1 mdl-typography--text-right"></div>
+<div class="content-cell mdl-cell mdl-cell--12-col mdl-typography--caption"><b>Products:</b><br>&emsp;Search<br></div></div></div></div>
+<div class="outer-cell mdl-cell mdl-cell--12-col mdl-shadow--2dp"><div class="mdl-grid">
+<div class="header-cell mdl-cell mdl-cell--12-col"><p class="mdl-typography--title">Search<br></p></div>
+<div class="content-cell mdl-cell mdl-cell--6-col mdl-typography--body-1">Visited&nbsp;<a href="https://www.google.com/url?q=http://www.adobe.com/creativecloud.html&amp;usg=AFQjCNH6fum5tBw7J0dbmUYKGFPduC0vSg">http://www.adobe.com/creativecloud.html</a><br>Feb 8, 2017, 12:32:39 AM</div>
+<div class="content-cell mdl-cell mdl-cell--6-col mdl-typography--body-1 mdl-typography--text-right"></div>
+<div class="content-cell mdl-cell mdl-cell--12-col mdl-typography--caption"><b>Products:</b><br>&emsp;Search<br></div></div></div>
+<div class="outer-cell mdl-cell mdl-cell--12-col mdl-shadow--2dp"><div class="mdl-grid">
+<div class="header-cell mdl-cell mdl-cell--12-col"><p class="mdl-typography--title">Search<br></p></div>
+<div class="content-cell mdl-cell mdl-cell--6-col mdl-typography--body-1">Searched for&nbsp;<a href="https://www.google.com/search?q=adobe+creative+cloud">adobe creative cloud</a><br>Feb 8, 2017, 12:32:36 AM</div>
+<div class="content-cell mdl-cell mdl-cell--6-col mdl-typography--body-1 mdl-typography--text-right"></div>
+<div class="content-cell mdl-cell mdl-cell--12-col mdl-typography--caption"><b>Products:</b><br>&emsp;Search<br><b>Locations:</b><br>&emsp;From your home: <a href="https://google.com/maps?q=25.800819,-80.186310">https://google.com/maps?q=25.800819,-80.186310</a>
+<br>
+</div></div></div></div></body>
+</html>


### PR DESCRIPTION
previously it resulted in
`TypeError: _parse_html_activity.<locals>.soup_filter() missing 1 required positional argument: 'data'`
    
Seems like it has to do some `SoupStrainer` changes menioned for 4.13 release in https://git.launchpad.net/beautifulsoup/tree/CHANGELOG
    
The fixed version works on 4.12 too, so backwards compatible
    
In addtition to the test in previous commit, checked against all my takeouts, parses the same results
