### PR TITLE
fix: explicit use of utf-8 for reading files

### DIFF
--- a/google_takeout_parser/parse_csv.py
+++ b/google_takeout_parser/parse_csv.py
@@ -50,7 +50,7 @@ def _parse_youtube_comments_buffer(buf: TextIO) -> Iterator[Res[CSVYoutubeCommen
 
 
 def _parse_youtube_comments_csv(path: Path) -> Iterator[Res[CSVYoutubeComment]]:
-    with path.open("r", newline="") as f:
+    with path.open("r", newline="", encoding="utf-8") as f:
         yield from _parse_youtube_comments_buffer(f)
 
 
@@ -96,7 +96,7 @@ def _parse_youtube_live_chats_buffer(
 
 
 def _parse_youtube_live_chats_csv(path: Path) -> Iterator[Res[CSVYoutubeLiveChat]]:
-    with path.open("r", newline="") as f:
+    with path.open("r", newline="", encoding="utf-8") as f:
         yield from _parse_youtube_live_chats_buffer(f)
 
 

--- a/google_takeout_parser/parse_json.py
+++ b/google_takeout_parser/parse_json.py
@@ -33,7 +33,7 @@ def _read_json_data(p: Path) -> Any:
         warnings.warn(
             "orjson not found, it can significantly speed up json parsing. Consider installing via 'pip install orjson'. Falling back onto stdlib json"
         )
-        return json.loads(p.read_text())
+        return json.loads(p.read_text(encoding="utf-8"))
     else:
         return orjson.loads(p.read_bytes())
 
@@ -42,7 +42,7 @@ def _read_json_data(p: Path) -> Any:
 # "YouTube and YouTube Music/history/watch-history.json"
 # This is also the 'My Activity' JSON format
 def _parse_json_activity(p: Path) -> Iterator[Res[Activity]]:
-    json_data = json.loads(p.read_text())
+    json_data = json.loads(p.read_text(encoding="utf-8"))
     if not isinstance(json_data, list):
         yield RuntimeError(f"Activity: Top level item in '{p}' isn't a list")
     for blob in json_data:
@@ -101,7 +101,7 @@ def _parse_json_activity(p: Path) -> Iterator[Res[Activity]]:
 
 
 def _parse_likes(p: Path) -> Iterator[Res[LikedYoutubeVideo]]:
-    json_data = json.loads(p.read_text())
+    json_data = json.loads(p.read_text(encoding="utf-8"))
     if not isinstance(json_data, list):
         yield RuntimeError(f"Likes: Top level item in '{p}' isn't a list")
     for jlike in json_data:
@@ -119,7 +119,7 @@ def _parse_likes(p: Path) -> Iterator[Res[LikedYoutubeVideo]]:
 
 
 def _parse_app_installs(p: Path) -> Iterator[Res[PlayStoreAppInstall]]:
-    json_data = json.loads(p.read_text())
+    json_data = json.loads(p.read_text(encoding="utf-8"))
     if not isinstance(json_data, list):
         yield RuntimeError(f"App installs: Top level item in '{p}' isn't a list")
     for japp in json_data:
@@ -193,7 +193,7 @@ def _check_required_keys(
 
 
 def _parse_semantic_location_history(p: Path) -> Iterator[Res[PlaceVisit]]:
-    json_data = json.loads(p.read_text())
+    json_data = json.loads(p.read_text(encoding="utf-8"))
     if not isinstance(json_data, dict):
         yield RuntimeError(f"Locations: Top level item in '{p}' isn't a dict")
     if "timelineObjects" not in json_data:
@@ -264,7 +264,7 @@ def _parse_semantic_location_history(p: Path) -> Iterator[Res[PlaceVisit]]:
 
 
 def _parse_chrome_history(p: Path) -> Iterator[Res[ChromeHistory]]:
-    json_data = json.loads(p.read_text())
+    json_data = json.loads(p.read_text(encoding="utf-8"))
     if "Browser History" not in json_data:
         yield RuntimeError(f"Chrome/BrowserHistory: no 'Browser History' key in '{p}'")
     for item in json_data.get("Browser History", []):


### PR DESCRIPTION
I was trying to open some files but got the following error:
![image](https://github.com/user-attachments/assets/d59cc5bf-aad7-488b-bb4c-b39f75e06bcb)

The error only happens on windows but not on Linux. I looked into it and it seems to be that python does not default to utf-8 for decoding when opening files on windows. I have explicitly added the utf-8 when reading files  which seems to fix the issue. I am not sure if this had been addressed/encountered before